### PR TITLE
RENO-1153: Adjust system-ui stack; update dgx-svg-icons package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ### v0.5.5
-- Update to @nypl/dgx-svg-icons 0.3.10.
+- Update to @nypl/dgx-svg-icons 0.3.11.
 - Adjusted width constraint on social media icons to avoid wrapping.
 - Adjusted system-ui font stack to account for Firefox v.75.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### v0.5.5
+- Update to @nypl/dgx-svg-icons 0.3.10.
+- Adjusted width constraint on social media icons to avoid wrapping.
+- Adjusted system-ui font stack to account for Firefox v.75.
+
 ### v0.5.4
 - Added system-font-css.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is the footer component for the ReactJS applications of nypl.org
 
 ### Version
 
-0.5.4
+0.5.5
 
 ### App Installation
 

--- a/dist/styles/styles.scss
+++ b/dist/styles/styles.scss
@@ -159,7 +159,7 @@ $nypl-white: #fff;
       list-style-type: none;
       // icons are square, we want four across
       text-align: right;
-      width: 45px * 4;
+      width: 50px * 4;
 
       li {
         display: inline-block;

--- a/dist/styles/styles.scss
+++ b/dist/styles/styles.scss
@@ -9,7 +9,7 @@ $nypl-white: #fff;
   background: $footer-color;
   clear: both;
   color: #fff;
-  font-family: system-ui, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   min-height: 280px;
   padding: 15px 20px 100px;
   position: relative;
@@ -159,7 +159,7 @@ $nypl-white: #fff;
       list-style-type: none;
       // icons are square, we want three across
       text-align: right;
-      width: 45px * 3;
+      width: 45px * 4;
 
       li {
         display: inline-block;
@@ -196,7 +196,6 @@ $nypl-white: #fff;
 
       // MQs for .socialMedia
       @include min-screen($portrait) {
-        width: 170px;
         margin-top: 30px;
       }
 
@@ -231,7 +230,7 @@ $nypl-white: #fff;
   .copyright {
     margin: 35px 0 0 0;
     font-size: 12px;
-    font-family: system-ui, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
     text-align: right;
 
     @include min-screen($portrait) {

--- a/dist/styles/styles.scss
+++ b/dist/styles/styles.scss
@@ -157,7 +157,7 @@ $nypl-white: #fff;
       order: 1;
       margin: 20px -6px 15px 0;
       list-style-type: none;
-      // icons are square, we want three across
+      // icons are square, we want four across
       text-align: right;
       width: 45px * 4;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@nypl/dgx-react-footer",
-  "version": "0.5.2",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@nypl/dgx-svg-icons": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.8.tgz",
-      "integrity": "sha512-HYdL3ZbhhgqlelzOvme9pqF/7ibi5sCsJDI0YtbalVaDrc6+F7MozVKB7qYfHH0lZ8BbqfiYDK10rxBq9mlvog=="
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.10.tgz",
+      "integrity": "sha512-hP/faKdi2yU5+7DkOFkDjXW6Nz5AgCh8x63kQqwC7nlIYbobzrk2zMidbhpxJl/hX4hwxN9bvpJAxoQN1RNssg=="
     },
     "Base64": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@nypl/dgx-svg-icons": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.10.tgz",
-      "integrity": "sha512-hP/faKdi2yU5+7DkOFkDjXW6Nz5AgCh8x63kQqwC7nlIYbobzrk2zMidbhpxJl/hX4hwxN9bvpJAxoQN1RNssg=="
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.11.tgz",
+      "integrity": "sha512-DdL/kGqFEmvUM5WO6ETWv2H03ZjDH6/XV21WqTIG6FomkkdxEfTaJqFwHUkNRq+XxMOEDG/FIP+JPqthxy+msQ=="
     },
     "Base64": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start": "NODE_ENV=development node server.js"
   },
   "dependencies": {
-    "@nypl/dgx-svg-icons": "0.3.10",
+    "@nypl/dgx-svg-icons": "0.3.11",
     "system-font-css": "^2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "email": "seanredmond@nypl.org"
     }
   ],
-  "version": "0.5.4",
+  "version": "0.5.5",
   "main": "dist/Footer.js",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
     "start": "NODE_ENV=development node server.js"
   },
   "dependencies": {
-    "@nypl/dgx-svg-icons": "0.3.8",
+    "@nypl/dgx-svg-icons": "0.3.10",
     "system-font-css": "^2.0.2"
   },
   "devDependencies": {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -9,7 +9,7 @@ $nypl-white: #fff;
   background: $footer-color;
   clear: both;
   color: #fff;
-  font-family: system-ui, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   min-height: 280px;
   padding: 15px 20px 100px;
   position: relative;
@@ -159,7 +159,7 @@ $nypl-white: #fff;
       list-style-type: none;
       // icons are square, we want three across
       text-align: right;
-      width: 45px * 3;
+      width: 45px * 4;
 
       li {
         display: inline-block;
@@ -196,7 +196,6 @@ $nypl-white: #fff;
 
       // MQs for .socialMedia
       @include min-screen($portrait) {
-        width: 170px;
         margin-top: 30px;
       }
 
@@ -231,7 +230,7 @@ $nypl-white: #fff;
   .copyright {
     margin: 35px 0 0 0;
     font-size: 12px;
-    font-family: system-ui, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
     text-align: right;
 
     @include min-screen($portrait) {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -157,9 +157,9 @@ $nypl-white: #fff;
       order: 1;
       margin: 20px -6px 15px 0;
       list-style-type: none;
-      // icons are square, we want three across
+      // icons are square, we want four across
       text-align: right;
-      width: 45px * 4;
+      width: 50px * 4;
 
       li {
         display: inline-block;


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**
- Update to @nypl/dgx-svg-icons 0.3.11.
- Adjusted width constraint on social media icons to avoid wrapping.
- Adjusted system-ui font stack to account for regression in Firefox v.75.