### PR TITLE
RENO-1463: Add urlType option to support absolute or relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is the footer component for the ReactJS applications of nypl.org
 
 ### Version
 
-0.5.6
+0.5.7
 
 ### App Installation
 
@@ -33,6 +33,14 @@ var Footer =  require('@nypl/dgx-react-footer');
 Call the instance in your application component:
 ```
 <Footer id="footer" className="footer" />
+```
+### Component Props
+
+- `urlType`: Type of URL's to be established for NYPL link elements. If empty, it will utilize `relative` URL's by default. If `absolute` URL's are required, such as for apps that live at a different domain, initialize the Footer component as follows:
+
+```sh
+  <Footer urlType='absolute' /> // Sets all URLs to absolute
+  <Footer /> // Sets all URLs to relative
 ```
 
 ### Styles

--- a/dist/Footer.js
+++ b/dist/Footer.js
@@ -37,7 +37,8 @@ var Footer = function Footer(props) {
       { className: props.className + '-content' },
       _react2.default.createElement(_FooterLinks2.default, {
         className: 'footerLinks',
-        data: _footerConfig2.default.nyplLinks
+        data: _footerConfig2.default.nyplLinks,
+        urlType: props.urlType
       }),
       _react2.default.createElement(_SocialMediaList2.default, {
         data: _footerConfig2.default.socialMedia,
@@ -83,12 +84,14 @@ var Footer = function Footer(props) {
 
 Footer.propTypes = {
   id: _propTypes2.default.string,
-  className: _propTypes2.default.string
+  className: _propTypes2.default.string,
+  urlType: _propTypes2.default.string
 };
 
 Footer.defaultProps = {
   id: 'footer',
-  className: 'footer'
+  className: 'footer',
+  urlType: 'relative'
 };
 
 exports.default = Footer;

--- a/dist/app.js
+++ b/dist/app.js
@@ -25,4 +25,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /* app.jsx
  * Used for local development of React Components
  */
-_reactDom2.default.render(_react2.default.createElement(_Footer2.default, { id: 'footer', className: 'footer' }), document.getElementById('footerPreview'));
+_reactDom2.default.render(_react2.default.createElement(_Footer2.default, { id: 'footer', className: 'footer', urlType: 'absolute' }), document.getElementById('footerPreview'));

--- a/dist/app.js
+++ b/dist/app.js
@@ -25,4 +25,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 /* app.jsx
  * Used for local development of React Components
  */
-_reactDom2.default.render(_react2.default.createElement(_Footer2.default, { id: 'footer', className: 'footer', urlType: 'absolute' }), document.getElementById('footerPreview'));
+_reactDom2.default.render(_react2.default.createElement(_Footer2.default, { id: 'footer', className: 'footer' }), document.getElementById('footerPreview'));

--- a/dist/components/FooterLinks/FooterLinks.js
+++ b/dist/components/FooterLinks/FooterLinks.js
@@ -18,26 +18,28 @@ var _LinksGroup2 = _interopRequireDefault(_LinksGroup);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var renderLinksGroups = function renderLinksGroups(data) {
+var renderLinksGroups = function renderLinksGroups(data, urlType) {
   return data.map(function (item, i) {
-    return _react2.default.createElement(_LinksGroup2.default, { data: item, key: i });
+    return _react2.default.createElement(_LinksGroup2.default, { data: item, key: i, urlType: urlType });
   });
 }; // Import libraries
 
 
 var FooterLinks = function FooterLinks(_ref) {
   var data = _ref.data,
-      className = _ref.className;
+      className = _ref.className,
+      urlType = _ref.urlType;
   return _react2.default.createElement(
     'ul',
     { className: className },
-    renderLinksGroups(data)
+    renderLinksGroups(data, urlType)
   );
 };
 
 FooterLinks.propTypes = {
   data: _propTypes2.default.array,
-  className: _propTypes2.default.string
+  className: _propTypes2.default.string,
+  urlType: _propTypes2.default.string
 };
 
 exports.default = FooterLinks;

--- a/dist/components/LinksGroup/LinksGroup.js
+++ b/dist/components/LinksGroup/LinksGroup.js
@@ -12,16 +12,9 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _utils = require('../../utils/utils.js');
 
-var convertUrlRelative = function convertUrlRelative(url) {
-  if (typeof url !== 'string') {
-    return '#';
-  }
-  var regex = new RegExp(/^http(s)?\:\/\/(www.)?nypl.org/i);
-  // Test regex matching pattern
-  return regex.test(url) ? url.replace(regex, '') : url;
-};
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var renderLinkItems = function renderLinkItems(data, urlType) {
   return data.map(function (item, i) {
@@ -31,7 +24,7 @@ var renderLinkItems = function renderLinkItems(data, urlType) {
       _react2.default.createElement(
         'a',
         {
-          href: urlType === 'absolute' ? item.link : convertUrlRelative(item.link)
+          href: urlType === 'absolute' ? item.link : (0, _utils.convertUrlRelative)(item.link)
         },
         item.name
       )

--- a/dist/components/LinksGroup/LinksGroup.js
+++ b/dist/components/LinksGroup/LinksGroup.js
@@ -14,14 +14,25 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var renderLinkItems = function renderLinkItems(data) {
+var convertUrlRelative = function convertUrlRelative(url) {
+  if (typeof url !== 'string') {
+    return '#';
+  }
+  var regex = new RegExp(/^http(s)?\:\/\/(www.)?nypl.org/i);
+  // Test regex matching pattern
+  return regex.test(url) ? url.replace(regex, '') : url;
+};
+
+var renderLinkItems = function renderLinkItems(data, urlType) {
   return data.map(function (item, i) {
     return _react2.default.createElement(
       'li',
       { key: i },
       _react2.default.createElement(
         'a',
-        { href: item.link },
+        {
+          href: urlType === 'absolute' ? item.link : convertUrlRelative(item.link)
+        },
         item.name
       )
     );
@@ -29,20 +40,22 @@ var renderLinkItems = function renderLinkItems(data) {
 };
 
 var LinksGroup = function LinksGroup(_ref) {
-  var data = _ref.data;
+  var data = _ref.data,
+      urlType = _ref.urlType;
   return _react2.default.createElement(
     'li',
     null,
     _react2.default.createElement(
       'ul',
       { className: 'linkItemList' },
-      renderLinkItems(data)
+      renderLinkItems(data, urlType)
     )
   );
 };
 
 LinksGroup.propTypes = {
-  data: _propTypes2.default.array
+  data: _propTypes2.default.array,
+  urlType: _propTypes2.default.string
 };
 
 exports.default = LinksGroup;

--- a/dist/footerConfig.js
+++ b/dist/footerConfig.js
@@ -6,37 +6,37 @@ Object.defineProperty(exports, "__esModule", {
 var data = {
   nyplLinks: [[{
     name: 'Accessibility',
-    link: '/accessibility'
+    link: 'http://www.nypl.org/accessibility'
   }, {
     name: 'Press',
-    link: '/help/about-nypl/media-center'
+    link: 'http://www.nypl.org/help/about-nypl/media-center'
   }, {
     name: 'Careers',
     link: '/careers'
   }, {
     name: 'Space Rental',
-    link: '/spacerental'
+    link: 'http://www.nypl.org/spacerental'
   }], [{
     name: 'Privacy Policy',
-    link: '/help/about-nypl/legal-notices/privacy-policy'
+    link: 'http://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'
   }, {
     name: 'Other Policies',
-    link: '/policies'
+    link: 'http://www.nypl.org/policies'
   }, {
     name: 'Terms & Conditions',
-    link: '/terms-conditions'
+    link: 'http://www.nypl.org/terms-conditions'
   }, {
     name: 'Governance',
-    link: '/help/about-nypl/leadership/board-trustees'
+    link: 'http://www.nypl.org/help/about-nypl/leadership/board-trustees'
   }], [{
     name: 'Rules & Regulations',
-    link: '/help/about-nypl/legal-notices/rules-and-regulations'
+    link: 'http://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'
   }, {
     name: 'About NYPL',
-    link: '/help/about-nypl'
+    link: 'http://www.nypl.org/help/about-nypl'
   }, {
     name: 'Language',
-    link: '/language'
+    link: 'http://www.nypl.org/language'
   }]],
   socialMedia: [{
     name: 'NYPL on Facebook',

--- a/dist/footerConfig.js
+++ b/dist/footerConfig.js
@@ -12,7 +12,7 @@ var data = {
     link: 'http://www.nypl.org/help/about-nypl/media-center'
   }, {
     name: 'Careers',
-    link: '/careers'
+    link: 'http://www.nypl.org/careers'
   }, {
     name: 'Space Rental',
     link: 'http://www.nypl.org/spacerental'

--- a/dist/utils/utils.js
+++ b/dist/utils/utils.js
@@ -1,0 +1,23 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+/**
+ * convertUrlRelative(url)
+ * A utility function to support the Footer component's urlType prop.
+ * If urlType is set to 'absolute', it will leave the url as-is. If not
+ * this function will remove the NYPL domain and convert the string to a relative link,
+ * which is more useful for QA and test environments.
+ * @param (String) Url 
+ */
+var convertUrlRelative = function convertUrlRelative(url) {
+  if (typeof url !== 'string') {
+    return '#';
+  }
+  var regex = new RegExp(/^http(s)?\:\/\/(www.)?nypl.org/i);
+  // Test regex matching pattern
+  return regex.test(url) ? url.replace(regex, '') : url;
+};
+
+exports.convertUrlRelative = convertUrlRelative;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-react-footer",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "email": "seanredmond@nypl.org"
     }
   ],
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "dist/Footer.js",
   "license": "MIT",
   "repository": {

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -12,6 +12,7 @@ const Footer = (props) => (
       <FooterLinks
         className="footerLinks"
         data={footerConfig.nyplLinks}
+        urlType={props.urlType}
       />
       <SocialMediaList
         data={footerConfig.socialMedia}
@@ -41,11 +42,13 @@ const Footer = (props) => (
 Footer.propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
+  urlType: PropTypes.string,
 };
 
 Footer.defaultProps = {
   id: 'footer',
   className: 'footer',
+  urlType: 'relative',
 };
 
 export default Footer;

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -10,6 +10,6 @@ a11y(React, { ReactDOM, includeSrcNode: true });
  * Used for local development of React Components
  */
 ReactDOM.render(
-  <Footer id="footer" className="footer" />,
+  <Footer id="footer" className="footer" urlType="absolute" />,
   document.getElementById('footerPreview')
 );

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -10,6 +10,6 @@ a11y(React, { ReactDOM, includeSrcNode: true });
  * Used for local development of React Components
  */
 ReactDOM.render(
-  <Footer id="footer" className="footer" urlType="absolute" />,
+  <Footer id="footer" className="footer" />,
   document.getElementById('footerPreview')
 );

--- a/src/components/FooterLinks/FooterLinks.js
+++ b/src/components/FooterLinks/FooterLinks.js
@@ -3,20 +3,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LinksGroup from './../LinksGroup/LinksGroup';
 
-const renderLinksGroups = (data) =>
+const renderLinksGroups = (data, urlType) =>
   data.map((item, i) =>
-    <LinksGroup data={item} key={i} />
+    <LinksGroup data={item} key={i} urlType={urlType} />
   );
 
-const FooterLinks = ({ data, className }) => (
+const FooterLinks = ({ data, className, urlType }) => (
   <ul className={className}>
-    {renderLinksGroups(data)}
+    {renderLinksGroups(data, urlType)}
   </ul>
 );
 
 FooterLinks.propTypes = {
   data: PropTypes.array,
   className: PropTypes.string,
+  urlType: PropTypes.string,
 };
 
 export default FooterLinks;

--- a/src/components/LinksGroup/LinksGroup.js
+++ b/src/components/LinksGroup/LinksGroup.js
@@ -1,25 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const renderLinkItems = (data) =>
+const convertUrlRelative = (url) => {
+  if (typeof url !== 'string') {
+    return '#';
+  }
+  const regex = new RegExp(/^http(s)?\:\/\/(www.)?nypl.org/i);
+  // Test regex matching pattern
+  return (regex.test(url)) ? url.replace(regex, '') : url;
+};
+
+const renderLinkItems = (data, urlType) =>
   data.map((item, i) =>
     <li key={i}>
-      <a href={item.link}>
+      <a 
+        href={(urlType === 'absolute') ? item.link : convertUrlRelative(item.link)}
+      >
         {item.name}
       </a>
     </li>
   );
 
-const LinksGroup = ({ data }) => (
+const LinksGroup = ({ data, urlType }) => (
   <li>
     <ul className="linkItemList">
-      {renderLinkItems(data)}
+      {renderLinkItems(data, urlType)}
     </ul>
   </li>
 );
 
 LinksGroup.propTypes = {
   data: PropTypes.array,
+  urlType: PropTypes.string,
 };
 
 export default LinksGroup;

--- a/src/components/LinksGroup/LinksGroup.js
+++ b/src/components/LinksGroup/LinksGroup.js
@@ -1,14 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const convertUrlRelative = (url) => {
-  if (typeof url !== 'string') {
-    return '#';
-  }
-  const regex = new RegExp(/^http(s)?\:\/\/(www.)?nypl.org/i);
-  // Test regex matching pattern
-  return (regex.test(url)) ? url.replace(regex, '') : url;
-};
+import { convertUrlRelative } from '../../utils/utils.js'
 
 const renderLinkItems = (data, urlType) =>
   data.map((item, i) =>

--- a/src/footerConfig.js
+++ b/src/footerConfig.js
@@ -11,7 +11,7 @@ const data = {
       },
       {
         name: 'Careers',
-        link: '/careers',
+        link: 'http://www.nypl.org/careers',
       },
       {
         name: 'Space Rental',

--- a/src/footerConfig.js
+++ b/src/footerConfig.js
@@ -3,11 +3,11 @@ const data = {
     [
       {
         name: 'Accessibility',
-        link: '/accessibility',
+        link: 'http://www.nypl.org/accessibility',
       },
       {
         name: 'Press',
-        link: '/help/about-nypl/media-center',
+        link: 'http://www.nypl.org/help/about-nypl/media-center',
       },
       {
         name: 'Careers',
@@ -15,39 +15,39 @@ const data = {
       },
       {
         name: 'Space Rental',
-        link: '/spacerental',
+        link: 'http://www.nypl.org/spacerental',
       },
     ],
     [
       {
         name: 'Privacy Policy',
-        link: '/help/about-nypl/legal-notices/privacy-policy',
+        link: 'http://www.nypl.org/help/about-nypl/legal-notices/privacy-policy',
       },
       {
         name: 'Other Policies',
-        link: '/policies',
+        link: 'http://www.nypl.org/policies',
       },
       {
         name: 'Terms & Conditions',
-        link: '/terms-conditions',
+        link: 'http://www.nypl.org/terms-conditions',
       },
       {
         name: 'Governance',
-        link: '/help/about-nypl/leadership/board-trustees',
+        link: 'http://www.nypl.org/help/about-nypl/leadership/board-trustees',
       },
     ],
     [
       {
         name: 'Rules & Regulations',
-        link: '/help/about-nypl/legal-notices/rules-and-regulations',
+        link: 'http://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations',
       },
       {
         name: 'About NYPL',
-        link: '/help/about-nypl',
+        link: 'http://www.nypl.org/help/about-nypl',
       },
       {
         name: 'Language',
-        link: '/language',
+        link: 'http://www.nypl.org/language',
       },
     ],
   ],

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,18 @@
+/**
+ * convertUrlRelative(url)
+ * A utility function to support the Footer component's urlType prop.
+ * If urlType is set to 'absolute', it will leave the url as-is. If not
+ * this function will remove the NYPL domain and convert the string to a relative link,
+ * which is more useful for QA and test environments.
+ * @param (String) Url 
+ */
+const convertUrlRelative = (url) => {
+  if (typeof url !== 'string') {
+    return '#';
+  }
+  const regex = new RegExp(/^http(s)?\:\/\/(www.)?nypl.org/i);
+  // Test regex matching pattern
+  return (regex.test(url)) ? url.replace(regex, '') : url;
+};
+
+export {convertUrlRelative};


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1463)

**This PR does the following:**
- Changes footer links to be stored as absolute urls
- Adds a new propType called `urlType`, which allows "absolute" to be passed into the Footer component
- Adds a function to make the links relative if the "absolute" prop is not passed in.

This work allows apps such as `sfr-bookfinder-front-end` to configure the footer component to use absolute links, since it lives at a different domain.

The rest of the apps will continue to get relative links by default, as that is more helpful during the QA process.

The approach is identical to the way the `dgx-header-component` handles it.

**Testing:**
- I tested this branch against a local version of `sfr-bookfinder-front-end` and it worked as expected.
- You can also test locally by adding the prop to the Footer component in app.jsx:

`<Footer id="footer" className="footer" urlType="absolute" />`