### PR TITLE
RENO-1705: Update dgx-svg-icons to 0.3.13 for HTML validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### v0.5.8
+- Update to @nypl/dgx-svg-icons 0.3.13.
+
+### v0.5.7
+- Add urlType option for absolute or relative links.
+
 ### v0.5.6
 - Update to @nypl/dgx-svg-icons 0.3.12.
 - Update to use NYPL "text-only" svg logo.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is the footer component for the ReactJS applications of nypl.org
 
 ### Version
 
-0.5.7
+0.5.8
 
 ### App Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@nypl/dgx-svg-icons": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.12.tgz",
-      "integrity": "sha512-Co92hdOAL04STAKLa2JFQPdo/As3NDDVsPf1aiAfMPLzMKr4T8914V+0fMmLRZ7QL9xVOuCWU2vgo4pUgE0DxA=="
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.13.tgz",
+      "integrity": "sha512-hCFFDS+s+ku+C7sJTzf5plafc6DCWxW5ZSy6bZFrpzsNkDfObVkARYGaLpRAgO1M7UdyOAmeuC4DPd1a1fwG1w=="
     },
     "Base64": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "email": "seanredmond@nypl.org"
     }
   ],
-  "version": "0.5.7",
+  "version": "0.5.8",
   "main": "dist/Footer.js",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
     "start": "NODE_ENV=development node server.js"
   },
   "dependencies": {
-    "@nypl/dgx-svg-icons": "0.3.12",
+    "@nypl/dgx-svg-icons": "0.3.13",
     "system-font-css": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1705)

**This PR does the following:**
- Update to @nypl/dgx-svg-icons 0.3.13 to fix HTML validation issue.

**To test:**
- Social media icon links should no longer have a title attribute on the `<svg>` element. This is covered by the `<title>` element "inside" the `<svg>`.